### PR TITLE
fix(og): use tableNo to match SPA query string convention

### DIFF
--- a/src/main/kotlin/com/kioschool/kioschoolapi/global/og/controller/OgController.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/global/og/controller/OgController.kt
@@ -31,11 +31,11 @@ class OgController(
     @GetMapping("/og/share/{workspaceId}")
     fun shareLink(
         @PathVariable workspaceId: Long,
-        @RequestParam(required = false) tableNumber: Int?,
+        @RequestParam(required = false) tableNo: Int?,
         @RequestParam(required = false) tableHash: String?,
         @RequestHeader(HttpHeaders.USER_AGENT, required = false) userAgent: String?,
     ): ResponseEntity<String> =
-        when (val action = ogFacade.resolveShareLink(workspaceId, tableNumber, tableHash, userAgent)) {
+        when (val action = ogFacade.resolveShareLink(workspaceId, tableNo, tableHash, userAgent)) {
             is ShareLinkAction.RenderOgHtml ->
                 ResponseEntity.ok()
                     .contentType(MediaType.parseMediaType("${MediaType.TEXT_HTML_VALUE};charset=UTF-8"))

--- a/src/main/kotlin/com/kioschool/kioschoolapi/global/og/facade/OgFacade.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/global/og/facade/OgFacade.kt
@@ -24,22 +24,24 @@ class OgFacade(
      * `/share/{workspaceId}` 진입을 봇/사람으로 분기.
      *
      * - 봇 → og 메타태그 미니 HTML (워크스페이스 단위 카드, 테이블 정보 무관)
-     * - 사람 → 실제 주문 페이지로 redirect URI. tableNumber/tableHash가 들어오면
+     * - 사람 → 실제 주문 페이지로 redirect URI. tableNo/tableHash가 들어오면
      *   query string에 보존해서 친구가 같은 테이블 세션에 합류 가능하도록.
      */
     fun resolveShareLink(
         workspaceId: Long,
-        tableNumber: Int?,
+        tableNo: Int?,
         tableHash: String?,
         userAgent: String?,
     ): ShareLinkAction {
         return if (isBot(userAgent)) {
             ShareLinkAction.RenderOgHtml(renderOrderHtml(workspaceId))
         } else {
+            // 프론트 SPA가 query string에서 `tableNo`를 읽는 컨벤션을 사용하므로
+            // 들어온 이름과 redirect URL에 박는 이름 모두 `tableNo`로 맞춘다.
             val target = UriComponentsBuilder.fromUriString("$baseUrl/order")
                 .queryParam("workspaceId", workspaceId)
                 .apply {
-                    tableNumber?.let { queryParam("tableNumber", it) }
+                    tableNo?.let { queryParam("tableNo", it) }
                     tableHash?.let { queryParam("tableHash", it) }
                 }
                 .build()

--- a/src/test/kotlin/com/kioschool/kioschoolapi/og/facade/OgFacadeTest.kt
+++ b/src/test/kotlin/com/kioschool/kioschoolapi/og/facade/OgFacadeTest.kt
@@ -83,7 +83,7 @@ class OgFacadeTest : DescribeSpec({
                 every { workspaceService.findWorkspaceOrNull(42L) } returns ws
                 every { ogService.renderOrderHtmlFor(ws, 42L) } returns "<html>og</html>"
 
-                val action = sut.resolveShareLink(42L, tableNumber = null, tableHash = null, userAgent = ua)
+                val action = sut.resolveShareLink(42L, tableNo = null, tableHash = null, userAgent = ua)
 
                 assert(action is ShareLinkAction.RenderOgHtml)
                 assert((action as ShareLinkAction.RenderOgHtml).body == "<html>og</html>")
@@ -97,7 +97,7 @@ class OgFacadeTest : DescribeSpec({
 
             val action = sut.resolveShareLink(
                 workspaceId = 42L,
-                tableNumber = 3,
+                tableNo = 3,
                 tableHash = "abc123",
                 userAgent = "KAKAOTALK",
             )
@@ -117,7 +117,7 @@ class OgFacadeTest : DescribeSpec({
 
         humanUas.forEach { ua ->
             it("returns RedirectToOrder for human UA: ${ua.take(40)}") {
-                val action = sut.resolveShareLink(42L, tableNumber = null, tableHash = null, userAgent = ua)
+                val action = sut.resolveShareLink(42L, tableNo = null, tableHash = null, userAgent = ua)
 
                 assert(action is ShareLinkAction.RedirectToOrder)
                 val target = (action as ShareLinkAction.RedirectToOrder).target.toString()
@@ -149,29 +149,29 @@ class OgFacadeTest : DescribeSpec({
             assert(target == "https://dev.kio-school.com/order?workspaceId=7")
         }
 
-        it("preserves tableNumber and tableHash in the redirect target") {
+        it("preserves tableNo and tableHash in the redirect target") {
             val action = sut.resolveShareLink(
                 workspaceId = 42L,
-                tableNumber = 3,
+                tableNo = 3,
                 tableHash = "abc123",
                 userAgent = "Chrome",
             )
 
             val target = (action as ShareLinkAction.RedirectToOrder).target.toString()
-            assert(target == "https://kio-school.com/order?workspaceId=42&tableNumber=3&tableHash=abc123") {
+            assert(target == "https://kio-school.com/order?workspaceId=42&tableNo=3&tableHash=abc123") {
                 "Expected redirect to include both table params, got: $target"
             }
         }
 
-        it("preserves only tableNumber when tableHash is absent") {
-            val action = sut.resolveShareLink(42L, tableNumber = 3, tableHash = null, userAgent = "Chrome")
+        it("preserves only tableNo when tableHash is absent") {
+            val action = sut.resolveShareLink(42L, tableNo = 3, tableHash = null, userAgent = "Chrome")
 
             val target = (action as ShareLinkAction.RedirectToOrder).target.toString()
-            assert(target == "https://kio-school.com/order?workspaceId=42&tableNumber=3")
+            assert(target == "https://kio-school.com/order?workspaceId=42&tableNo=3")
         }
 
-        it("preserves only tableHash when tableNumber is absent") {
-            val action = sut.resolveShareLink(42L, tableNumber = null, tableHash = "abc123", userAgent = "Chrome")
+        it("preserves only tableHash when tableNo is absent") {
+            val action = sut.resolveShareLink(42L, tableNo = null, tableHash = "abc123", userAgent = "Chrome")
 
             val target = (action as ShareLinkAction.RedirectToOrder).target.toString()
             assert(target == "https://kio-school.com/order?workspaceId=42&tableHash=abc123")
@@ -180,7 +180,7 @@ class OgFacadeTest : DescribeSpec({
         it("URL-encodes tableHash to handle special characters safely") {
             val action = sut.resolveShareLink(
                 workspaceId = 42L,
-                tableNumber = null,
+                tableNo = null,
                 tableHash = "hash with spaces & symbols",
                 userAgent = "Chrome",
             )


### PR DESCRIPTION
## 문제

PR #12에서 share link redirect URL 빌드 시 `tableNumber` query param을 썼는데, **프론트 SPA의 `/order` 페이지가 query string에서 `tableNo`를 읽고 있음**. 따라서:

- 사장님 share URL: `kio-school.com/share/42?tableNo=3&tableHash=abc` (프론트가 보내는 형태)
- 백엔드는 `tableNumber` param으로 받으려 했으나 `tableNo`로 들어와 매칭 안 됨 → null 처리
- redirect URL: `?workspaceId=42&tableHash=abc` (tableNo 누락)
- SPA 진입 → 테이블 번호 못 읽음 → 친구가 같은 테이블 합류 실패

## 변경

`OgController.shareLink` + `OgFacade.resolveShareLink` + redirect URL builder 모두 `tableNumber` → `tableNo`로 통일. 프론트가 사용하는 query string 컨벤션(`tableNo`)과 일치시킴.

```kotlin
// Before
@RequestParam(required = false) tableNumber: Int?,
...
tableNumber?.let { queryParam("tableNumber", it) }

// After
@RequestParam(required = false) tableNo: Int?,
...
tableNo?.let { queryParam("tableNo", it) }
```

## 다른 API 영역은 그대로

- `POST /order` body DTO: `tableNumber: Int` (그대로)
- `GET /order/available?tableNumber=N`: 그대로
- 기타 Order/AdminOrder controller params: `tableNumber` (그대로)

이 PR이 건드리는 건 **URL routing layer (share link → SPA URL)** 한정. JSON body / API param convention은 별개로, 이미 SPA가 알아서 변환하고 있음 (URL `tableNo` → API body `tableNumber`).

## 테스트

```
./gradlew test --tests "*OgControllerTest*" --tests "*OgFacadeTest*"
→ 25/25 SUCCESS
```

테스트들도 `tableNumber` → `tableNo`로 일괄 갱신 + redirect URL assertion이 새 컨벤션 검증.

## 검증 (머지 후, dev 기준)

```bash
# 직접 호출 — redirect URL에 tableNo 포함되는지
curl -i 'https://dev-api.kio-school.com/og/share/55?tableNo=3&tableHash=abc' | grep -i location
# → Location: https://dev.kio-school.com/order?workspaceId=55&tableNo=3&tableHash=abc

# Amplify 룰 적용 후 end-to-end
curl -i 'https://dev.kio-school.com/share/55?tableNo=3&tableHash=abc' | grep -i location
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)