### PR TITLE
fix(og): tighten BOT_PATTERN to exclude SNS in-app browsers

### DIFF
--- a/src/main/kotlin/com/kioschool/kioschoolapi/global/og/facade/OgFacade.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/global/og/facade/OgFacade.kt
@@ -56,9 +56,20 @@ class OgFacade(
     }
 
     companion object {
+        // 봇 전용 토큰만 매칭. webview/in-app browser가 자기 식별자(KAKAOTALK 9.7.0,
+        // NAVER, Daum 등)를 UA에 포함시키는 케이스가 많아서 광범위한 토큰은 사용자를
+        // 봇으로 오인시킨다. 카카오톡 모바일 in-app browser 사용자가 share link를
+        // 클릭했을 때 og HTML을 받아 빈 화면을 보던 사고를 막기 위해 정밀화.
+        //
+        // 봇 전용 식별자 매핑:
+        //   - 카카오톡 preview crawler:    Kakaotalk-Scrap (in-app은 KAKAOTALK/x.x.x (INAPP))
+        //   - 카카오스토리 preview crawler: kakaostory-Scrap
+        //   - 네이버 검색 봇:              Yeti
+        //   - 다음 검색 봇:                Daumoa
+        //   - WhatsApp link preview:      WhatsApp/x.x.x (슬래시로 in-app과 구분)
         private val BOT_PATTERN: Pattern = Pattern.compile(
-            "(?i)(facebookexternalhit|KAKAOTALK|kakaostory|Slackbot|Twitterbot|" +
-                "Discordbot|TelegramBot|LinkedInBot|WhatsApp|naver|Yeti|Daum|Googlebot|bingbot)"
+            "(?i)(facebookexternalhit|Kakaotalk-Scrap|kakaostory-Scrap|Slackbot|Twitterbot|" +
+                "Discordbot|TelegramBot|LinkedInBot|WhatsApp/|Yeti|Daumoa|Googlebot|bingbot)"
         )
     }
 }

--- a/src/test/kotlin/com/kioschool/kioschoolapi/og/facade/OgFacadeTest.kt
+++ b/src/test/kotlin/com/kioschool/kioschoolapi/og/facade/OgFacadeTest.kt
@@ -68,13 +68,22 @@ class OgFacadeTest : DescribeSpec({
     }
 
     describe("resolveShareLink — bot branch") {
+        // 실제 SNS link preview crawler가 보내는 UA. 모바일 in-app browser와 구분되는
+        // 봇 전용 토큰(*-Scrap, Yeti, Daumoa, WhatsApp/x.x.x 등)이 들어있는 패턴.
         val botUas = listOf(
-            "Mozilla/5.0 (compatible; KAKAOTALK 9.0.0)",
             "facebookexternalhit/1.1",
+            "Mozilla/5.0 (compatible; Kakaotalk-Scrap/1.0; +https://devtalk.kakao.com/)",
+            "Mozilla/5.0 (compatible; kakaostory-Scrap/1.0)",
             "Slackbot-LinkExpanding 1.0",
             "Mozilla/5.0 (compatible; Googlebot/2.1)",
             "Twitterbot/1.0",
             "Mozilla/5.0 (compatible; bingbot/2.0)",
+            "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)",
+            "TelegramBot (like TwitterBot)",
+            "LinkedInBot/1.0",
+            "WhatsApp/2.23.20.0 A",
+            "Mozilla/5.0 (compatible; Yeti/1.1; +https://naver.me/spd)",
+            "Mozilla/5.0 (compatible; Daumoa/3.0; +http://cs.daum.net/faq/15/4118.html?faqId=28966)",
         )
 
         botUas.forEach { ua ->
@@ -85,7 +94,7 @@ class OgFacadeTest : DescribeSpec({
 
                 val action = sut.resolveShareLink(42L, tableNo = null, tableHash = null, userAgent = ua)
 
-                assert(action is ShareLinkAction.RenderOgHtml)
+                assert(action is ShareLinkAction.RenderOgHtml) { "Expected bot for UA: $ua" }
                 assert((action as ShareLinkAction.RenderOgHtml).body == "<html>og</html>")
             }
         }
@@ -99,7 +108,7 @@ class OgFacadeTest : DescribeSpec({
                 workspaceId = 42L,
                 tableNo = 3,
                 tableHash = "abc123",
-                userAgent = "KAKAOTALK",
+                userAgent = "Mozilla/5.0 (compatible; Kakaotalk-Scrap/1.0)",
             )
 
             assert(action is ShareLinkAction.RenderOgHtml)
@@ -109,10 +118,21 @@ class OgFacadeTest : DescribeSpec({
     }
 
     describe("resolveShareLink — human branch") {
+        // 실제 사용자가 SNS in-app browser나 일반 브라우저에서 share link를 클릭할 때
+        // 보내는 UA. 모바일 webview는 보통 자기 앱 식별자(KAKAOTALK/x.x.x (INAPP),
+        // NAVER(inapp), DiscordIOS 등)를 UA에 포함시키지만 모두 사람이라 redirect돼야 함.
         val humanUas = listOf(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36",
             "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1",
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Firefox/120.0",
+            // dev에서 잡힌 실제 카카오톡 iOS in-app browser UA — 가장 결정적인 케이스
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1 KAKAOTALK/26.3.5 (INAPP)",
+            // Android 카카오톡 in-app browser 일반적 형태
+            "Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 Chrome/89.0.4389.105 Mobile Safari/537.36;KAKAOTALK 9.7.0",
+            // 네이버 앱 in-app browser
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148 NAVER(inapp; search; 1234; 12.0.0)",
+            // 다음 앱 in-app browser
+            "Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 Chrome/89 Mobile Safari/537.36 Daum/iOS",
         )
 
         humanUas.forEach { ua ->


### PR DESCRIPTION
## 무엇을

dev에서 확인된 잠재 버그 fix. **모바일 카카오톡에서 share 링크 클릭 시 redirect 안 되고 빈 화면이 보이는 문제**.

## 증상

PC 브라우저: 클릭 → `/order?workspaceId=N&tableNo=...`로 정상 redirect ✓
모바일 카카오톡 in-app browser: 클릭 → `/share/...` 그대로, 흰 화면 ❌

## 원인 — GCP 로그에서 결정적 증거 캡처

```
--> OgController#shareLink() called with args:
    [1, 1, "f911640d-...", "Mozilla/5.0 (iPhone; ...) Mobile/15E148 Safari/604.1
                            KAKAOTALK/26.3.5 (INAPP)"]

<-- returned: { "statusCode": "OK" (200),
               "headers": {"Content-Type": "text/html;charset=UTF-8"},
               "body": "<!doctype html>...<body></body></html>" }
```

카카오톡 iOS in-app webview UA에 `KAKAOTALK/26.3.5 (INAPP)`이 들어있는데, 우리 regex `KAKAOTALK`이 매칭 → 사용자를 봇으로 분류 → og HTML(빈 body)을 반환 → 사용자가 흰 화면을 봄.

UA에 `(INAPP)` 마커가 명시되어 있어 봇과 명확히 구분되는데도, regex가 너무 광범위해서 잠재 버그였던 것이 모바일 사용자 클릭 시 처음 표면화.

## 변경

### `OgFacade.BOT_PATTERN` 정밀화

| 기존 | 수정 | 이유 |
|---|---|---|
| `KAKAOTALK` | `Kakaotalk-Scrap` | in-app browser는 `KAKAOTALK/x.x.x (INAPP)`, 봇은 `Kakaotalk-Scrap/1.0` |
| `kakaostory` | `kakaostory-Scrap` | 카카오스토리도 같은 -Scrap 패턴 |
| `WhatsApp` | `WhatsApp/` | 봇은 `WhatsApp/2.x.x.x` (슬래시 포함) |
| `naver` | (제거) | 너무 광범위. `Yeti`(네이버 검색 봇)만 남김 |
| `Daum` | `Daumoa` | 다음 검색 봇 토큰 |
| 기타 | 변경 없음 | facebookexternalhit, Slackbot, Twitterbot, Discordbot, TelegramBot, LinkedInBot, Googlebot, bingbot, Yeti는 봇 전용 |

### 테스트 fixture 현실화

기존 봇 UA fixture가 `Mozilla/5.0 (compatible; KAKAOTALK 9.0.0)` 같은 합성 패턴이라 실제 카카오 webview UA와 구분 못 함. 실제 SNS crawler UA로 교체:

```kotlin
// 봇 fixture (12종)
"Mozilla/5.0 (compatible; Kakaotalk-Scrap/1.0; +https://devtalk.kakao.com/)"
"Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)"
"Mozilla/5.0 (compatible; Yeti/1.1; +https://naver.me/spd)"
"Mozilla/5.0 (compatible; Daumoa/3.0; +http://cs.daum.net/...)"
"WhatsApp/2.23.20.0 A"
... (facebookexternalhit, Slackbot, Twitterbot, kakaostory-Scrap, ...)
```

### 사람 fixture에 in-app browser 추가

dev에서 실제로 잡힌 카카오톡 iOS in-app UA 그대로 + Android 카카오, 네이버 앱, 다음 앱 in-app도 함께. 모두 redirect돼야 정상.

```kotlin
// 사람 fixture (7종)
"Mozilla/5.0 (Macintosh) ... Chrome/120 ..."
"Mozilla/5.0 (iPhone; ...) ... Safari/604.1"
"Mozilla/5.0 (Windows ...) Firefox/120"
// 결정적 케이스 (dev 로그에서 직접 캡처)
"Mozilla/5.0 (iPhone; ...) Mobile/15E148 Safari/604.1 KAKAOTALK/26.3.5 (INAPP)"
// Android 카카오, 네이버 앱, 다음 앱 in-app
...
```

## 테스트

```
./gradlew test --tests "*OgFacadeTest*" --tests "*OgControllerTest*"
→ 36/36 SUCCESS
```

- 봇 12종: 모두 RenderOgHtml 응답
- 사람 7종 (in-app 4 포함): 모두 RedirectToOrder 응답
- 기존 케이스 17 (rendering, table 보존, baseUrl 분리): 그대로 통과

## 머지 후 검증

```bash
# dev에서 사용자 UA로 호출 — 302 응답 와야
curl -i -H 'User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1 KAKAOTALK/26.3.5 (INAPP)' \
     'https://dev-api.kio-school.com/og/share/1?tableNo=1&tableHash=abc'
# 기대: HTTP 302 + Location: https://dev.kio-school.com/order?workspaceId=1&tableNo=1&tableHash=abc

# 봇은 그대로 og HTML
curl -i -H 'User-Agent: Mozilla/5.0 (compatible; Kakaotalk-Scrap/1.0; +https://devtalk.kakao.com/)' \
     'https://dev-api.kio-school.com/og/share/1' | head -20
# 기대: HTTP 200 + og:* 메타태그

# end-to-end (Amplify 거친)
curl -i -H 'User-Agent: ...KAKAOTALK/26.3.5 (INAPP)' \
     'https://dev.kio-school.com/share/1?tableNo=1&tableHash=abc' | head -10
```

머지 + dev 재배포 후 모바일 카카오톡에서 같은 share 링크 클릭하면 정상 redirect 동작 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)