### PR TITLE
FIX - PortOne 계좌 검증 우회 결함 수정

### DIFF
--- a/src/main/kotlin/com/kioschool/kioschoolapi/global/portone/dto/BaseResponse.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/global/portone/dto/BaseResponse.kt
@@ -3,5 +3,5 @@ package com.kioschool.kioschoolapi.global.portone.dto
 class BaseResponse<T>(
     val code: Int,
     val message: String?,
-    val response: T
+    val response: T?
 )

--- a/src/main/kotlin/com/kioschool/kioschoolapi/global/portone/service/PortoneService.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/global/portone/service/PortoneService.kt
@@ -23,7 +23,12 @@ class PortoneService(
         val accessToken = getAccessToken()
 
         val response = portoneApi.getAccountHolder(accessToken, bank, accountNumber).execute()
-        val realAccountHolder = response.body()?.response?.bank_holder ?: ""
+        val body = response.body()
+        val realAccountHolder = body?.response?.bank_holder
+
+        if (body == null || body.code != 0 || realAccountHolder.isNullOrBlank()) {
+            throw IncorrectAccountHolderException()
+        }
 
         if (!accountHolder.startsWith(realAccountHolder)) {
             throw IncorrectAccountHolderException()


### PR DESCRIPTION
## 📚 개요

PortOne 계좌 실명조회가 실패했을 때 계좌 검증이 **무조건 통과되던 결함**을 수정했습니다.

### 문제 상황

기존 `PortoneService.validateAccountHolder` 로직은 PortOne 응답이 비어있을 때 `realAccountHolder`를 빈 문자열로 fallback 했습니다.

```kotlin
val realAccountHolder = response.body()?.response?.bank_holder ?: ""

if (!accountHolder.startsWith(realAccountHolder)) {  // "이름".startsWith("") = true (항상)
    throw IncorrectAccountHolderException()
}
```

Kotlin의 `String.startsWith("")`는 **항상 true**라서, PortOne이 빈 응답을 돌려주는 모든 케이스에서 검증이 그대로 통과됐습니다.

### 재현

실제 PortOne API에 존재하지 않는 계좌(예: SC제일은행 `11111`)로 조회를 보내면 다음과 같이 응답합니다.

```json
{"code":-1,"message":"해당되는 계좌정보를 찾을 수 없습니다.","response":null}
```

이 응답이 들어오면 `body.response`가 null이라 `realAccountHolder = ""`가 되고, 사용자가 아무 이름이나 입력해도 검증을 통과해 가짜 계좌로 등록이 가능했습니다.

### 영향

| 케이스 | 수정 전 | 수정 후 |
|---|---|---|
| 정상 개인 계좌 | ✅ 통과 | ✅ 통과 |
| 존재하지 않는 계좌 | ❌ **잘못 통과** | ✅ 거부 |
| PortOne 장애로 무응답 | ❌ **잘못 통과** | ✅ 거부 |
| 응답 스키마 변경 / 빈 `bank_holder` | ❌ **잘못 통과** | ✅ 거부 |

### 변경 내용

- **`PortoneService.kt`** — PortOne 응답 유효성 검증과 예금주명 일치 검증을 두 개의 `if` 문으로 분리. `body == null`, `body.code != 0`, `bank_holder`가 null/blank인 경우 즉시 `IncorrectAccountHolderException`을 던집니다.
- **`BaseResponse.kt`** — `response: T`를 `response: T?`로 변경. PortOne이 실제로 `response: null`을 돌려주는 응답 스키마와 일치시켜 다른 호출부의 잠재적 NPE를 방지합니다.

### 결정 노트

- **예금주명 일치 검증 자체(`startsWith`)는 손대지 않음** — 토스뱅크 모임통장(`이은지(모임통장)` 같이 PortOne이 부가 표시를 붙여 돌려주는 경우)에서 정상 계좌가 거부되는 별도 이슈가 있으나, 이는 개인의 입력 정책으로 처리할 영역이라 판단해 이번 핫픽스 범위에서 제외했습니다.

## 🕐 리뷰 예상 시간

> 3m

## ❗❗ 중요한 변경점

1. **보안 결함 핫픽스**입니다. 머지 후 가능한 한 빨리 배포해야 합니다.
2. `BaseResponse<T>.response`가 nullable로 바뀌면서 PortOne dto를 사용하는 다른 호출부에 영향이 갈 수 있습니다. 현재 확인된 사용처(`getAccessToken()`)는 이미 `?.` 체이닝을 쓰고 있어 호환되지만, 추가 호출부 도입 시 주의가 필요합니다.
3. 기존엔 PortOne 일시 장애에도 검증을 통과시키던 코드가 이제 명시적으로 거부합니다. 운영상 PortOne 장애 시 모든 계좌 등록이 막힐 수 있으니, 알림/모니터링 관점에서 인지 필요합니다.