### PR TITLE
ADD - 워크스페이스 대표 사진 초점 지정 API

### DIFF
--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/controller/AdminWorkspaceController.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/controller/AdminWorkspaceController.kt
@@ -77,13 +77,13 @@ class AdminWorkspaceController(
     @PutMapping("/workspace/image")
     fun updateWorkspaceImage(
         @AdminUsername username: String,
-        @RequestPart body: UpdateWorkspaceImageRequestBody,
+        @Valid @RequestPart body: UpdateWorkspaceImageRequestBody,
         @RequestPart(required = false) imageFiles: List<MultipartFile>?,
     ): WorkspaceDto {
         return workspaceFacade.updateWorkspaceImage(
             username,
             body.workspaceId,
-            body.imageIds,
+            body,
             imageFiles ?: emptyList()
         )
     }

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/dto/common/FocalPointDto.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/dto/common/FocalPointDto.kt
@@ -1,0 +1,18 @@
+package com.kioschool.kioschoolapi.domain.workspace.dto.common
+
+/**
+ * 사진에서 항상 화면에 남아야 할 지점을 원본 대비 퍼센트로 나타낸다.
+ * 프론트는 이 값을 CSS object-position으로 적용한다.
+ */
+data class FocalPointDto(val x: Int, val y: Int) {
+    fun isInRange() = x in MIN..MAX && y in MIN..MAX
+
+    companion object {
+        const val MIN = 0
+        const val MAX = 100
+        const val CENTER_VALUE = 50
+
+        // 지정된 초점이 없을 때의 기본값. 초점 도입 이전의 정중앙 크롭과 같은 결과를 낸다.
+        val CENTER = FocalPointDto(CENTER_VALUE, CENTER_VALUE)
+    }
+}

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/dto/common/WorkspaceImageDto.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/dto/common/WorkspaceImageDto.kt
@@ -6,6 +6,7 @@ import java.time.LocalDateTime
 data class WorkspaceImageDto(
     val id: Long,
     val url: String,
+    val focalPoint: FocalPointDto,
     val createdAt: LocalDateTime?,
     val updatedAt: LocalDateTime?
 ) {
@@ -14,6 +15,7 @@ data class WorkspaceImageDto(
             return WorkspaceImageDto(
                 id = workspaceImage.id,
                 url = workspaceImage.url,
+                focalPoint = FocalPointDto(workspaceImage.focalX, workspaceImage.focalY),
                 createdAt = workspaceImage.createdAt,
                 updatedAt = workspaceImage.updatedAt
             )

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/dto/common/WorkspaceImageSlot.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/dto/common/WorkspaceImageSlot.kt
@@ -1,0 +1,22 @@
+package com.kioschool.kioschoolapi.domain.workspace.dto.common
+
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * 대표 사진 슬롯 한 칸. 빈 슬롯은 아예 만들지 않는다.
+ * focalPoint가 null이면 "이번 요청에 지정이 없다"는 뜻이며,
+ * 기존 이미지는 저장된 값을 유지하고 신규 파일만 기본값을 쓴다.
+ */
+sealed class WorkspaceImageSlot {
+    abstract val focalPoint: FocalPointDto?
+
+    data class Existing(
+        val imageId: Long,
+        override val focalPoint: FocalPointDto?,
+    ) : WorkspaceImageSlot()
+
+    data class New(
+        val file: MultipartFile,
+        override val focalPoint: FocalPointDto?,
+    ) : WorkspaceImageSlot()
+}

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/dto/request/UpdateWorkspaceImageRequestBody.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/dto/request/UpdateWorkspaceImageRequestBody.kt
@@ -1,10 +1,53 @@
 package com.kioschool.kioschoolapi.domain.workspace.dto.request
 
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.FocalPointDto
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.WorkspaceImageSlot
 import com.kioschool.kioschoolapi.global.common.interfaces.WorkspaceAware
+import com.kioschool.kioschoolapi.global.error.ErrorCode
+import com.kioschool.kioschoolapi.global.error.exception.CustomException
 import jakarta.validation.constraints.Size
+import org.springframework.web.multipart.MultipartFile
 
 class UpdateWorkspaceImageRequestBody(
     override val workspaceId: Long,
-    @Size(min = 3, max = 3, message = "이미지 아이디는 3개여야 합니다.")
-    val imageIds: List<Long?>
-) : WorkspaceAware
+    @field:Size(min = 3, max = 3, message = "이미지 아이디는 3개여야 합니다.")
+    val imageIds: List<Long?>,
+    // 프론트보다 백엔드를 먼저 배포해도 깨지지 않도록 optional.
+    @field:Size(min = 3, max = 3, message = "이미지 초점은 3개여야 합니다.")
+    val focalPoints: List<FocalPointDto?>? = null,
+) : WorkspaceAware {
+
+    /**
+     * imageFiles는 multipart라 null을 담을 수 없어, 프론트가 빈 슬롯을 뒤로 몰아 압축한
+     * 순서로 파일만 보낸다. 슬롯 인덱스와 파일을 다시 맞춰야 초점이 올바른 사진에 붙는다.
+     */
+    fun toSlots(imageFiles: List<MultipartFile>): List<WorkspaceImageSlot> {
+        validateFocalPoints()
+
+        val fileIterator = imageFiles.iterator()
+        val slots = mutableListOf<WorkspaceImageSlot>()
+
+        imageIds.forEachIndexed { index, imageId ->
+            val focalPoint = focalPoints?.getOrNull(index)
+            when {
+                imageId != null -> slots.add(WorkspaceImageSlot.Existing(imageId, focalPoint))
+                fileIterator.hasNext() -> slots.add(
+                    WorkspaceImageSlot.New(fileIterator.next(), focalPoint)
+                )
+            }
+        }
+
+        // 파일이 남았다는 건 압축 규칙이 깨졌다는 뜻이다. 그대로 두면 엉뚱한 사진에 초점이 붙는다.
+        if (fileIterator.hasNext()) {
+            throw CustomException(ErrorCode.WORKSPACE_IMAGE_SLOT_MISMATCH)
+        }
+
+        return slots
+    }
+
+    private fun validateFocalPoints() {
+        focalPoints?.filterNotNull()?.forEach {
+            if (!it.isInRange()) throw CustomException(ErrorCode.INVALID_IMAGE_FOCAL_POINT)
+        }
+    }
+}

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/entity/WorkspaceImage.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/entity/WorkspaceImage.kt
@@ -1,7 +1,9 @@
 package com.kioschool.kioschoolapi.domain.workspace.entity
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.FocalPointDto
 import com.kioschool.kioschoolapi.global.common.entity.BaseEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.ManyToOne
@@ -13,5 +15,11 @@ class WorkspaceImage(
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     val workspace: Workspace,
-    var url: String
+    var url: String,
+    // 두 필드 모두 명시적 컬럼명 필수: Hibernate의 CamelCaseToUnderscoresNamingStrategy는 이름 끝의
+    // 대문자 한 글자에 언더스코어를 넣지 않아, 암시적 매핑은 focalx/focaly가 된다.
+    @Column(name = "focal_x")
+    var focalX: Int = FocalPointDto.CENTER_VALUE,
+    @Column(name = "focal_y")
+    var focalY: Int = FocalPointDto.CENTER_VALUE,
 ) : BaseEntity()

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/facade/WorkspaceFacade.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/facade/WorkspaceFacade.kt
@@ -10,6 +10,7 @@ import com.kioschool.kioschoolapi.domain.workspace.dto.common.TablePositionUpdat
 import com.kioschool.kioschoolapi.domain.workspace.dto.common.WorkspaceAdminDetailDto
 import com.kioschool.kioschoolapi.domain.workspace.dto.common.WorkspaceDto
 import com.kioschool.kioschoolapi.domain.workspace.dto.common.WorkspaceTableDto
+import com.kioschool.kioschoolapi.domain.workspace.dto.request.UpdateWorkspaceImageRequestBody
 import com.kioschool.kioschoolapi.domain.workspace.service.WorkspaceService
 import com.kioschool.kioschoolapi.global.cache.constant.CacheNames
 import com.kioschool.kioschoolapi.global.discord.service.DiscordService
@@ -148,7 +149,7 @@ class WorkspaceFacade(
     fun updateWorkspaceImage(
         username: String,
         workspaceId: Long,
-        imageIds: List<Long?>,
+        body: UpdateWorkspaceImageRequestBody,
         imageFiles: List<MultipartFile>,
     ): WorkspaceDto {
         val user = userService.getUser(username)
@@ -156,10 +157,12 @@ class WorkspaceFacade(
 
         workspaceService.checkCanAccessWorkspace(user, workspace)
 
-        val deleteImages = workspace.images.filter { !imageIds.contains(it.id) }
+        val slots = body.toSlots(imageFiles)
+
+        val deleteImages = workspace.images.filter { !body.imageIds.contains(it.id) }
         workspaceService.deleteWorkspaceImages(workspace, deleteImages)
 
-        return WorkspaceDto.of(workspaceService.saveWorkspaceImages(workspace, imageFiles))
+        return WorkspaceDto.of(workspaceService.applyImageSlots(workspace, slots))
     }
 
     fun getAllWorkspaceTables(username: String, workspaceId: Long): List<WorkspaceTableDto> {

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/service/WorkspaceService.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/workspace/service/WorkspaceService.kt
@@ -2,8 +2,10 @@ package com.kioschool.kioschoolapi.domain.workspace.service
 
 import com.kioschool.kioschoolapi.domain.user.entity.User
 import com.kioschool.kioschoolapi.domain.user.service.UserService
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.FocalPointDto
 import com.kioschool.kioschoolapi.domain.workspace.dto.common.TablePositionDto
 import com.kioschool.kioschoolapi.domain.workspace.dto.common.TablePositionUpdateDto
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.WorkspaceImageSlot
 import com.kioschool.kioschoolapi.domain.workspace.entity.*
 import com.kioschool.kioschoolapi.domain.workspace.repository.CustomWorkspaceRepository
 import com.kioschool.kioschoolapi.domain.workspace.repository.WorkspaceMemberRepository
@@ -24,7 +26,6 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.multipart.MultipartFile
 import java.time.LocalDateTime
 import java.util.*
 
@@ -170,13 +171,40 @@ class WorkspaceService(
 
     @Transactional
     @WorkspaceUpdateEvent
-    fun saveWorkspaceImages(workspace: Workspace, newImageFiles: List<MultipartFile>): Workspace {
-        newImageFiles.forEach {
-            val path =
-                "$workspacePath/workspace${workspace.id}/workspace/${System.currentTimeMillis()}.webp"
-            val imageUrl = s3Service.uploadResizedWebpImage(it.inputStream, path)
-            workspace.images.add(WorkspaceImage(workspace = workspace, url = imageUrl))
+    fun applyImageSlots(workspace: Workspace, slots: List<WorkspaceImageSlot>): Workspace {
+        val imagesById = workspace.images.associateBy { it.id }
+
+        slots.forEachIndexed { index, slot ->
+            when (slot) {
+                is WorkspaceImageSlot.Existing -> {
+                    // 존재 검증은 workspace의 실제 이미지를 알 수 없는 UpdateWorkspaceImageRequestBody.toSlots()에서
+                    // 여기로 미뤄졌다. workspace.images는 워크스페이스 범위로 한정된 관계라 다른 워크스페이스의
+                    // 이미지가 섞일 일이 없으므로, 존재하지 않거나 오래된 imageId는 여기서 조용히 무시해도 안전하다.
+                    val image = imagesById[slot.imageId] ?: return@forEachIndexed
+                    slot.focalPoint?.let {
+                        image.focalX = it.x
+                        image.focalY = it.y
+                    }
+                }
+
+                is WorkspaceImageSlot.New -> {
+                    // 한 요청에 여러 장을 올리면 currentTimeMillis가 같을 수 있어 슬롯 인덱스로 구분한다.
+                    val path =
+                        "$workspacePath/workspace${workspace.id}/workspace/${System.currentTimeMillis()}-$index.webp"
+                    val imageUrl = s3Service.uploadResizedWebpImage(slot.file.inputStream, path)
+                    val focalPoint = slot.focalPoint ?: FocalPointDto.CENTER
+                    workspace.images.add(
+                        WorkspaceImage(
+                            workspace = workspace,
+                            url = imageUrl,
+                            focalX = focalPoint.x,
+                            focalY = focalPoint.y,
+                        )
+                    )
+                }
+            }
         }
+
         return workspaceRepository.save(workspace)
     }
 

--- a/src/main/kotlin/com/kioschool/kioschoolapi/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/global/error/ErrorCode.kt
@@ -28,6 +28,8 @@ enum class ErrorCode(
     SUPER_ADMIN_WORKSPACE_READ_ONLY(HttpStatus.BAD_REQUEST, "최고 관리자(Super Admin)는 타인의 워크스페이스를 조회만 할 수 있으며, 수정(CUD)은 불가능합니다."),
     TABLE_POSITION_CONFLICT(HttpStatus.CONFLICT, "해당 위치에 이미 다른 테이블이 배치되어 있습니다."),
     INVALID_TABLE_POSITION(HttpStatus.BAD_REQUEST, "테이블 위치가 올바르지 않습니다."),
+    INVALID_IMAGE_FOCAL_POINT(HttpStatus.BAD_REQUEST, "이미지 초점 위치가 올바르지 않습니다."),
+    WORKSPACE_IMAGE_SLOT_MISMATCH(HttpStatus.BAD_REQUEST, "이미지 파일 수가 올바르지 않습니다."),
 
     // Product
     NOT_FOUND_PRODUCT(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),

--- a/src/main/resources/db/changelog/2026/09/06-01-changelog.xml
+++ b/src/main/resources/db/changelog/2026/09/06-01-changelog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+  <changeSet author="ji-inpark" id="1788700000000-1">
+    <addColumn tableName="workspace_image">
+      <column name="focal_x" type="INT" defaultValueNumeric="50">
+        <constraints nullable="false"/>
+      </column>
+      <column name="focal_y" type="INT" defaultValueNumeric="50">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/kotlin/com/kioschool/kioschoolapi/workspace/dto/FocalPointDtoTest.kt
+++ b/src/test/kotlin/com/kioschool/kioschoolapi/workspace/dto/FocalPointDtoTest.kt
@@ -1,0 +1,31 @@
+package com.kioschool.kioschoolapi.workspace.dto
+
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.FocalPointDto
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class FocalPointDtoTest : DescribeSpec({
+    describe("isInRange") {
+        it("should accept values inside 0..100") {
+            FocalPointDto(0, 0).isInRange() shouldBe true
+            FocalPointDto(50, 50).isInRange() shouldBe true
+            FocalPointDto(100, 100).isInRange() shouldBe true
+        }
+
+        it("should reject values below 0") {
+            FocalPointDto(-1, 50).isInRange() shouldBe false
+            FocalPointDto(50, -1).isInRange() shouldBe false
+        }
+
+        it("should reject values above 100") {
+            FocalPointDto(101, 50).isInRange() shouldBe false
+            FocalPointDto(50, 101).isInRange() shouldBe false
+        }
+    }
+
+    describe("CENTER") {
+        it("should be the midpoint, matching the previous center-crop behaviour") {
+            FocalPointDto.CENTER shouldBe FocalPointDto(50, 50)
+        }
+    }
+})

--- a/src/test/kotlin/com/kioschool/kioschoolapi/workspace/dto/UpdateWorkspaceImageRequestBodyTest.kt
+++ b/src/test/kotlin/com/kioschool/kioschoolapi/workspace/dto/UpdateWorkspaceImageRequestBodyTest.kt
@@ -9,12 +9,35 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
+import jakarta.validation.Validation
 import org.junit.jupiter.api.assertThrows
 import org.springframework.web.multipart.MultipartFile
 
 class UpdateWorkspaceImageRequestBodyTest : DescribeSpec({
     val fileA = mockk<MultipartFile>()
     val fileB = mockk<MultipartFile>()
+
+    describe("field validation") {
+        val validator = Validation.buildDefaultValidatorFactory().validator
+
+        it("should reject imageIds with a length other than 3") {
+            val violations = validator.validate(UpdateWorkspaceImageRequestBody(1L, listOf(1L, null), null))
+
+            violations.map { it.propertyPath.toString() } shouldBe listOf("imageIds")
+        }
+
+        it("should reject focalPoints with a length other than 3") {
+            val violations = validator.validate(
+                UpdateWorkspaceImageRequestBody(1L, listOf(1L, null, null), listOf(FocalPointDto(0, 0))),
+            )
+
+            violations.map { it.propertyPath.toString() } shouldBe listOf("focalPoints")
+        }
+
+        it("should accept a well-formed request") {
+            validator.validate(UpdateWorkspaceImageRequestBody(1L, listOf(1L, null, null), null)).shouldBeEmpty()
+        }
+    }
 
     describe("toSlots") {
         it("should map existing images to Existing slots with their focal points") {

--- a/src/test/kotlin/com/kioschool/kioschoolapi/workspace/dto/UpdateWorkspaceImageRequestBodyTest.kt
+++ b/src/test/kotlin/com/kioschool/kioschoolapi/workspace/dto/UpdateWorkspaceImageRequestBodyTest.kt
@@ -1,0 +1,100 @@
+package com.kioschool.kioschoolapi.workspace.dto
+
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.FocalPointDto
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.WorkspaceImageSlot
+import com.kioschool.kioschoolapi.domain.workspace.dto.request.UpdateWorkspaceImageRequestBody
+import com.kioschool.kioschoolapi.global.error.ErrorCode
+import com.kioschool.kioschoolapi.global.error.exception.CustomException
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.jupiter.api.assertThrows
+import org.springframework.web.multipart.MultipartFile
+
+class UpdateWorkspaceImageRequestBodyTest : DescribeSpec({
+    val fileA = mockk<MultipartFile>()
+    val fileB = mockk<MultipartFile>()
+
+    describe("toSlots") {
+        it("should map existing images to Existing slots with their focal points") {
+            val body = UpdateWorkspaceImageRequestBody(
+                workspaceId = 1L,
+                imageIds = listOf(10L, 11L, null),
+                focalPoints = listOf(FocalPointDto(20, 30), FocalPointDto(40, 50), null),
+            )
+
+            body.toSlots(emptyList()) shouldBe listOf(
+                WorkspaceImageSlot.Existing(10L, FocalPointDto(20, 30)),
+                WorkspaceImageSlot.Existing(11L, FocalPointDto(40, 50)),
+            )
+        }
+
+        it("should map uploaded files to the empty slots in order") {
+            val body = UpdateWorkspaceImageRequestBody(
+                workspaceId = 1L,
+                imageIds = listOf(null, null, null),
+                focalPoints = listOf(FocalPointDto(10, 10), FocalPointDto(20, 20), null),
+            )
+
+            body.toSlots(listOf(fileA, fileB)) shouldBe listOf(
+                WorkspaceImageSlot.New(fileA, FocalPointDto(10, 10)),
+                WorkspaceImageSlot.New(fileB, FocalPointDto(20, 20)),
+            )
+        }
+
+        it("should map a mix of existing images and uploaded files by slot index") {
+            val body = UpdateWorkspaceImageRequestBody(
+                workspaceId = 1L,
+                imageIds = listOf(10L, null, null),
+                focalPoints = listOf(FocalPointDto(0, 0), FocalPointDto(60, 70), null),
+            )
+
+            body.toSlots(listOf(fileA)) shouldBe listOf(
+                WorkspaceImageSlot.Existing(10L, FocalPointDto(0, 0)),
+                WorkspaceImageSlot.New(fileA, FocalPointDto(60, 70)),
+            )
+        }
+
+        it("should keep focal points null when the client did not send any") {
+            val body = UpdateWorkspaceImageRequestBody(
+                workspaceId = 1L,
+                imageIds = listOf(10L, null, null),
+                focalPoints = null,
+            )
+
+            body.toSlots(listOf(fileA)) shouldBe listOf(
+                WorkspaceImageSlot.Existing(10L, null),
+                WorkspaceImageSlot.New(fileA, null),
+            )
+        }
+
+        it("should reject more files than empty slots") {
+            val body = UpdateWorkspaceImageRequestBody(
+                workspaceId = 1L,
+                imageIds = listOf(10L, 11L, null),
+                focalPoints = null,
+            )
+
+            val exception = assertThrows<CustomException> { body.toSlots(listOf(fileA, fileB)) }
+            exception.errorCode shouldBe ErrorCode.WORKSPACE_IMAGE_SLOT_MISMATCH
+        }
+
+        it("should reject a focal point outside 0..100") {
+            val body = UpdateWorkspaceImageRequestBody(
+                workspaceId = 1L,
+                imageIds = listOf(10L, null, null),
+                focalPoints = listOf(FocalPointDto(101, 50), null, null),
+            )
+
+            val exception = assertThrows<CustomException> { body.toSlots(emptyList()) }
+            exception.errorCode shouldBe ErrorCode.INVALID_IMAGE_FOCAL_POINT
+        }
+
+        it("should produce no slots for an empty workspace") {
+            UpdateWorkspaceImageRequestBody(1L, listOf(null, null, null), null)
+                .toSlots(emptyList())
+                .shouldBeEmpty()
+        }
+    }
+})

--- a/src/test/kotlin/com/kioschool/kioschoolapi/workspace/dto/WorkspaceImageDtoTest.kt
+++ b/src/test/kotlin/com/kioschool/kioschoolapi/workspace/dto/WorkspaceImageDtoTest.kt
@@ -1,0 +1,29 @@
+package com.kioschool.kioschoolapi.workspace.dto
+
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.FocalPointDto
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.WorkspaceImageDto
+import com.kioschool.kioschoolapi.factory.SampleEntity
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class WorkspaceImageDtoTest : DescribeSpec({
+    describe("of") {
+        it("should expose the stored focal point") {
+            val image = SampleEntity.workspaceImage1.apply {
+                focalX = 30
+                focalY = 12
+            }
+
+            WorkspaceImageDto.of(image).focalPoint shouldBe FocalPointDto(30, 12)
+        }
+
+        it("should expose the center focal point for an image that was never adjusted") {
+            val image = SampleEntity.workspaceImage2.apply {
+                focalX = FocalPointDto.CENTER_VALUE
+                focalY = FocalPointDto.CENTER_VALUE
+            }
+
+            WorkspaceImageDto.of(image).focalPoint shouldBe FocalPointDto.CENTER
+        }
+    }
+})

--- a/src/test/kotlin/com/kioschool/kioschoolapi/workspace/facade/WorkspaceFacadeTest.kt
+++ b/src/test/kotlin/com/kioschool/kioschoolapi/workspace/facade/WorkspaceFacadeTest.kt
@@ -17,6 +17,10 @@ import io.mockk.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
 import org.springframework.web.multipart.MultipartFile
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.FocalPointDto
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.WorkspaceImageSlot
+import com.kioschool.kioschoolapi.domain.workspace.dto.request.UpdateWorkspaceImageRequestBody
+import io.kotest.matchers.shouldBe
 
 class WorkspaceFacadeTest : DescribeSpec({
     val userService = mockk<UserService>()
@@ -510,152 +514,119 @@ class WorkspaceFacadeTest : DescribeSpec({
             SampleEntity.workspace.images.clear()
         }
 
-        it("should call userService.getUser, workspaceService.getWorkspace, workspaceService.deleteWorkspaceImages, workspaceService.saveWorkspaceImages and workspaceService.saveWorkspace") {
+        it("should check access, delete removed images and apply the slots") {
             val username = "username"
             val user = SampleEntity.user
             val workspaceId = 1L
             val workspace = SampleEntity.workspace.apply {
                 images.addAll(SampleEntity.workspaceImages)
             }
-            val imageIds = listOf(1L, 2L, 3L)
-            val imageFiles =
-                listOf(mockk<MultipartFile>(), mockk<MultipartFile>(), mockk<MultipartFile>())
-
+            val body = UpdateWorkspaceImageRequestBody(
+                workspaceId = workspaceId,
+                imageIds = listOf(1L, 2L, 3L),
+                focalPoints = listOf(FocalPointDto(10, 20), null, null),
+            )
 
             every { userService.getUser(username) } returns user
             every { workspaceService.getWorkspace(workspaceId) } returns workspace
             every { workspaceService.checkCanAccessWorkspace(user, workspace) } just Runs
             every { workspaceService.deleteWorkspaceImages(workspace, any()) } just Runs
             every {
-                workspaceService.saveWorkspaceImages(
-                    workspace,
-                    any<List<MultipartFile>>(),
-                )
+                workspaceService.applyImageSlots(workspace, any<List<WorkspaceImageSlot>>())
             } returns workspace
 
-            val result = sut.updateWorkspaceImage(
-                username,
-                workspaceId,
-                imageIds,
-                imageFiles,
-            )
+            val result = sut.updateWorkspaceImage(username, workspaceId, body, emptyList())
 
             assert(result.id == workspace.id)
 
-            verify { userService.getUser(username) }
-            verify { workspaceService.getWorkspace(workspaceId) }
             verify { workspaceService.checkCanAccessWorkspace(user, workspace) }
-            verify { workspaceService.deleteWorkspaceImages(workspace, any()) }
-            verify { workspaceService.saveWorkspaceImages(workspace, any<List<MultipartFile>>()) }
+            verify {
+                workspaceService.applyImageSlots(
+                    workspace,
+                    listOf(
+                        WorkspaceImageSlot.Existing(1L, FocalPointDto(10, 20)),
+                        WorkspaceImageSlot.Existing(2L, null),
+                        WorkspaceImageSlot.Existing(3L, null),
+                    ),
+                )
+            }
         }
 
-        it("should delete workspace images when imageIds is not exist and save workspace images") {
+        it("should delete images that are not kept") {
             val username = "username"
             val user = SampleEntity.user
             val workspaceId = 1L
             val workspace = SampleEntity.workspace.apply {
                 images.addAll(SampleEntity.workspaceImages)
             }
-            val imageIds = listOf(workspace.images[2].id, null, null)
-            val imageFiles =
-                listOf(mockk<MultipartFile>(), mockk<MultipartFile>())
+            val body = UpdateWorkspaceImageRequestBody(
+                workspaceId = workspaceId,
+                imageIds = listOf(1L, null, null),
+                focalPoints = null,
+            )
+            val deleted = slot<List<com.kioschool.kioschoolapi.domain.workspace.entity.WorkspaceImage>>()
 
             every { userService.getUser(username) } returns user
             every { workspaceService.getWorkspace(workspaceId) } returns workspace
             every { workspaceService.checkCanAccessWorkspace(user, workspace) } just Runs
+            every { workspaceService.deleteWorkspaceImages(workspace, capture(deleted)) } just Runs
             every {
-                workspaceService.deleteWorkspaceImages(
-                    workspace,
-                    arrayListOf(workspace.images[0], workspace.images[1])
-                )
-            } just Runs
-            every {
-                workspaceService.saveWorkspaceImages(
-                    workspace,
-                    imageFiles
-                )
+                workspaceService.applyImageSlots(workspace, any<List<WorkspaceImageSlot>>())
             } returns workspace
 
-            val result = sut.updateWorkspaceImage(
-                username,
-                workspaceId,
-                imageIds,
-                imageFiles
-            )
+            sut.updateWorkspaceImage(username, workspaceId, body, emptyList())
 
-            assert(result.id == workspace.id)
-
-            verify { userService.getUser(username) }
-            verify { workspaceService.getWorkspace(workspaceId) }
-            verify { workspaceService.checkCanAccessWorkspace(user, workspace) }
-            verify {
-                workspaceService.deleteWorkspaceImages(
-                    workspace,
-                    arrayListOf(workspace.images[0], workspace.images[1])
-                )
-            }
-            verify { workspaceService.saveWorkspaceImages(workspace, imageFiles) }
+            deleted.captured.map { it.id } shouldBe listOf(2L, 3L)
         }
 
-        it("should throw CustomException(USER_NOT_FOUND) when user not found") {
-            val username = "username"
-            val workspaceId = 1L
-            val imageIds = listOf(1L, 2L, 3L)
-            val imageFiles =
-                listOf(mockk<MultipartFile>(), mockk<MultipartFile>(), mockk<MultipartFile>())
-
-            every { userService.getUser(username) } throws CustomException(ErrorCode.USER_NOT_FOUND)
-
-            val ex = assertThrows<CustomException> {
-                sut.updateWorkspaceImage(
-                    username,
-                    workspaceId,
-                    imageIds,
-                    imageFiles
-                )
-            }
-            assertEquals(ErrorCode.USER_NOT_FOUND, ex.errorCode)
-
-            verify { userService.getUser(username) }
-            verify(exactly = 0) { workspaceService.getWorkspace(any()) }
-            verify(exactly = 0) { workspaceService.checkCanAccessWorkspace(any(), any()) }
-            verify(exactly = 0) { workspaceService.deleteWorkspaceImages(any(), any()) }
-            verify(exactly = 0) { workspaceService.saveWorkspaceImages(any(), any()) }
-        }
-
-        it("should throw CustomException(WORKSPACE_INACCESSIBLE) when user has no permission to update workspace") {
+        it("should check access before rejecting a malformed slot mapping") {
             val username = "username"
             val user = SampleEntity.user
             val workspaceId = 1L
             val workspace = SampleEntity.workspace
-            val imageIds = listOf(1L, 2L, 3L)
-            val imageFiles =
-                listOf(mockk<MultipartFile>(), mockk<MultipartFile>(), mockk<MultipartFile>())
+            val body = UpdateWorkspaceImageRequestBody(
+                workspaceId = workspaceId,
+                imageIds = listOf(1L, 2L, 3L),
+                focalPoints = null,
+            )
+
+            every { userService.getUser(username) } returns user
+            every { workspaceService.getWorkspace(workspaceId) } returns workspace
+            every { workspaceService.checkCanAccessWorkspace(user, workspace) } just Runs
+            every { workspaceService.deleteWorkspaceImages(workspace, any()) } just Runs
+
+            val exception = assertThrows<CustomException> {
+                sut.updateWorkspaceImage(username, workspaceId, body, listOf(mockk()))
+            }
+
+            exception.errorCode shouldBe ErrorCode.WORKSPACE_IMAGE_SLOT_MISMATCH
+            verify { workspaceService.checkCanAccessWorkspace(user, workspace) }
+        }
+
+        it("should propagate access denial before touching images") {
+            val username = "username"
+            val user = SampleEntity.user
+            val workspaceId = 1L
+            val workspace = SampleEntity.workspace
+            val body = UpdateWorkspaceImageRequestBody(
+                workspaceId = workspaceId,
+                imageIds = listOf(1L, 2L, 3L),
+                focalPoints = null,
+            )
 
             every { userService.getUser(username) } returns user
             every { workspaceService.getWorkspace(workspaceId) } returns workspace
             every {
-                workspaceService.checkCanAccessWorkspace(
-                    user,
-                    workspace
-                )
+                workspaceService.checkCanAccessWorkspace(user, workspace)
             } throws CustomException(ErrorCode.WORKSPACE_INACCESSIBLE)
 
-            val ex = assertThrows<CustomException> {
-                sut.updateWorkspaceImage(
-                    username,
-                    workspaceId,
-                    imageIds,
-                    imageFiles
-                )
+            val exception = assertThrows<CustomException> {
+                sut.updateWorkspaceImage(username, workspaceId, body, emptyList())
             }
-            assertEquals(ErrorCode.WORKSPACE_INACCESSIBLE, ex.errorCode)
 
-            verify { userService.getUser(username) }
-            verify { workspaceService.getWorkspace(workspaceId) }
-            verify { workspaceService.checkCanAccessWorkspace(user, workspace) }
+            exception.errorCode shouldBe ErrorCode.WORKSPACE_INACCESSIBLE
             verify(exactly = 0) { workspaceService.deleteWorkspaceImages(any(), any()) }
-            verify(exactly = 0) { workspaceService.saveWorkspaceImages(any(), any()) }
+            verify(exactly = 0) { workspaceService.applyImageSlots(any(), any()) }
         }
     }
 

--- a/src/test/kotlin/com/kioschool/kioschoolapi/workspace/service/WorkspaceServiceTest.kt
+++ b/src/test/kotlin/com/kioschool/kioschoolapi/workspace/service/WorkspaceServiceTest.kt
@@ -1,8 +1,10 @@
 package com.kioschool.kioschoolapi.workspace.service
 
 import com.kioschool.kioschoolapi.domain.user.service.UserService
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.FocalPointDto
 import com.kioschool.kioschoolapi.domain.workspace.dto.common.TablePositionDto
 import com.kioschool.kioschoolapi.domain.workspace.dto.common.TablePositionUpdateDto
+import com.kioschool.kioschoolapi.domain.workspace.dto.common.WorkspaceImageSlot
 import com.kioschool.kioschoolapi.domain.workspace.entity.WorkspaceTable
 import com.kioschool.kioschoolapi.domain.workspace.repository.WorkspaceRepository
 import com.kioschool.kioschoolapi.domain.workspace.repository.CustomWorkspaceRepository
@@ -20,6 +22,7 @@ import io.mockk.*
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.web.multipart.MultipartFile
+import java.io.ByteArrayInputStream
 import java.util.*
 import com.kioschool.kioschoolapi.domain.workspace.repository.WorkspaceMemberRepository
 
@@ -442,25 +445,99 @@ class WorkspaceServiceTest : DescribeSpec({
         }
     }
 
-    describe("saveWorkspaceImages") {
-        it("should save workspace images") {
+    describe("applyImageSlots") {
+        beforeTest {
+            SampleEntity.workspace.images.clear()
+        }
+
+        it("should update the focal point of an existing image") {
+            val workspace = SampleEntity.workspace.apply {
+                images.add(SampleEntity.workspaceImage1.apply { focalX = 50; focalY = 50 })
+            }
+            every { repository.save(workspace) } returns workspace
+
+            sut.applyImageSlots(
+                workspace,
+                listOf(WorkspaceImageSlot.Existing(1L, FocalPointDto(20, 12))),
+            )
+
+            SampleEntity.workspaceImage1.focalX shouldBe 20
+            SampleEntity.workspaceImage1.focalY shouldBe 12
+        }
+
+        it("should keep the stored focal point when the slot carries none") {
+            val workspace = SampleEntity.workspace.apply {
+                images.add(SampleEntity.workspaceImage1.apply { focalX = 30; focalY = 40 })
+            }
+            every { repository.save(workspace) } returns workspace
+
+            sut.applyImageSlots(workspace, listOf(WorkspaceImageSlot.Existing(1L, null)))
+
+            SampleEntity.workspaceImage1.focalX shouldBe 30
+            SampleEntity.workspaceImage1.focalY shouldBe 40
+        }
+
+        it("should upload a new file and attach its focal point") {
             val workspace = SampleEntity.workspace
-            val newImageFiles = listOf(mockk<MultipartFile>(), mockk<MultipartFile>())
-            newImageFiles.forEach { every { it.inputStream } returns java.io.ByteArrayInputStream(ByteArray(0)) }
+            val file = mockk<MultipartFile>()
+            every { file.inputStream } returns ByteArrayInputStream(ByteArray(0))
+            every { s3Service.uploadResizedWebpImage(any(), any()) } returns "uploaded-url"
+            every { repository.save(workspace) } returns workspace
 
-            every {
-                s3Service.uploadResizedWebpImage(any(), any<String>())
-            } returns "imageUrl"
-            every {
-                repository.save(workspace)
-            } returns workspace
+            sut.applyImageSlots(
+                workspace,
+                listOf(WorkspaceImageSlot.New(file, FocalPointDto(70, 80))),
+            )
 
-            val result = sut.saveWorkspaceImages(workspace, newImageFiles)
+            workspace.images.size shouldBe 1
+            workspace.images.first().url shouldBe "uploaded-url"
+            workspace.images.first().focalX shouldBe 70
+            workspace.images.first().focalY shouldBe 80
+        }
 
-            assert(result == workspace)
+        it("should default a new file to the center when the slot carries no focal point") {
+            val workspace = SampleEntity.workspace
+            val file = mockk<MultipartFile>()
+            every { file.inputStream } returns ByteArrayInputStream(ByteArray(0))
+            every { s3Service.uploadResizedWebpImage(any(), any()) } returns "uploaded-url"
+            every { repository.save(workspace) } returns workspace
 
-            verify(exactly = 2) { s3Service.uploadResizedWebpImage(any(), any<String>()) }
-            verify { repository.save(workspace) }
+            sut.applyImageSlots(workspace, listOf(WorkspaceImageSlot.New(file, null)))
+
+            workspace.images.first().focalX shouldBe FocalPointDto.CENTER_VALUE
+            workspace.images.first().focalY shouldBe FocalPointDto.CENTER_VALUE
+        }
+
+        it("should give each uploaded file a distinct path within the same millisecond") {
+            val workspace = SampleEntity.workspace
+            val file = mockk<MultipartFile>()
+            every { file.inputStream } returns ByteArrayInputStream(ByteArray(0))
+            val paths = mutableListOf<String>()
+            every { s3Service.uploadResizedWebpImage(any(), capture(paths)) } returns "uploaded-url"
+            every { repository.save(workspace) } returns workspace
+
+            sut.applyImageSlots(
+                workspace,
+                listOf(
+                    WorkspaceImageSlot.New(file, null),
+                    WorkspaceImageSlot.New(file, null),
+                ),
+            )
+
+            paths.toSet().size shouldBe 2
+        }
+
+        it("should silently skip a slot whose imageId does not match any image in the workspace") {
+            val workspace = SampleEntity.workspace.apply {
+                images.add(SampleEntity.workspaceImage1.apply { focalX = 30; focalY = 40 })
+            }
+            every { repository.save(workspace) } returns workspace
+
+            sut.applyImageSlots(workspace, listOf(WorkspaceImageSlot.Existing(999L, FocalPointDto(0, 0))))
+
+            workspace.images.size shouldBe 1
+            SampleEntity.workspaceImage1.focalX shouldBe 30
+            SampleEntity.workspaceImage1.focalY shouldBe 40
         }
     }
 


### PR DESCRIPTION
## 📚 개요

워크스페이스 대표 사진이 항상 정중앙으로 잘려서, 사장님이 의도한 구도가 손님 화면에서 잘려나가는 문제를 해결합니다. 사진마다 초점 좌표(x/y 퍼센트)를 저장하고, 프론트가 이를 `object-position`으로 적용합니다.

- `WorkspaceImage`에 `focalX`/`focalY` 컬럼 추가 (기본값 50/50 = 기존 정중앙 크롭과 동일, 마이그레이션 무영향)
- `PUT /workspace/image`가 슬롯별 초점 좌표(`focalPoints`)를 받아 저장하도록 확장
- 슬롯↔파일 매핑 검증(`WORKSPACE_IMAGE_SLOT_MISMATCH`), 초점 범위 검증(`INVALID_IMAGE_FOCAL_POINT`) 추가
- 접근 권한 검사 → 슬롯 검증 → 이미지 삭제 → 저장 순서로 재정렬 (403이 400보다 먼저 나가도록, S3 삭제가 검증 실패보다 먼저 일어나지 않도록)
- `@Valid` 누락으로 죽어있던 `imageIds`/`focalPoints` 길이 검증 활성화

설계 문서: `docs/superpowers/specs/2026-09-06-workspace-image-focal-point-design.md`
구현 계획: `docs/superpowers/plans/2026-09-06-workspace-image-focal-point.md` (Task 1-7)

프론트엔드 대응 PR: https://github.com/KioSchool/KioSchool/pull/543 — 백엔드가 먼저 배포되어도 `focalPoints`가 optional이라 구버전 프론트와 호환됩니다.

## 🕐 리뷰 예상 시간

> 20m

## ❗❗ 중요한 변경점(Option)

- `WorkspaceFacade.updateWorkspaceImage`: 접근 검사(`checkCanAccessWorkspace`) → 슬롯 검증(`toSlots`) → 삭제 → 저장 순서입니다. 접근 검사가 슬롯 검증보다 먼저 와야 권한 없는 워크스페이스에 잘못된 요청을 보냈을 때 400이 아니라 403이 나갑니다. 슬롯 검증(파일 개수 불일치 시 예외)이 이미지 삭제보다 먼저 와야, 검증에 실패한 요청이 기존 사진을 S3에서 먼저 지워버리는 일이 없습니다.
- `UpdateWorkspaceImageRequestBody.toSlots()`의 슬롯↔파일 재정렬 로직 — 프론트가 "빈 슬롯은 항상 뒤로 압축해서 보낸다"는 전제로 파일 목록을 압축해서 보내는데, 이 전제가 깨지면 (`WORKSPACE_IMAGE_SLOT_MISMATCH`) 예외를 던져 조용히 잘못된 사진에 초점이 붙는 걸 막습니다.
- `WorkspaceImage.focalX`/`focalY`는 명시적 `@Column(name=)`이 필수입니다 — Hibernate의 네이밍 전략이 끝이 대문자로 끝나는 필드명(`focalX`)의 언더스코어를 누락시키는 알려진 함정이며, `EntityColumnNamingTest`가 이를 자동으로 잡습니다.
