### PR TITLE
feat(donation): 손님 후원 버튼 클릭 카운트 API

### DIFF
--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/controller/DonationController.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/controller/DonationController.kt
@@ -1,0 +1,40 @@
+package com.kioschool.kioschoolapi.domain.donation.controller
+
+import com.kioschool.kioschoolapi.domain.donation.dto.common.CustomerDonationClickCountResponse
+import com.kioschool.kioschoolapi.domain.donation.dto.request.RecordCustomerDonationClickRequestBody
+import com.kioschool.kioschoolapi.domain.donation.facade.CustomerDonationFacade
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Donation Controller")
+@RestController
+class DonationController(
+    private val customerDonationFacade: CustomerDonationFacade
+) {
+    @Operation(
+        summary = "손님 후원 버튼 클릭 기록",
+        description = "손님이 주문 완료 화면 후원 모달의 송금 버튼을 누를 때 호출합니다. 로그인 불필요. 오늘 누적 클릭 수를 반환합니다."
+    )
+    @PostMapping("/donations/customer-clicks")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun recordCustomerDonationClick(
+        @RequestBody body: RecordCustomerDonationClickRequestBody
+    ): CustomerDonationClickCountResponse {
+        return customerDonationFacade.recordClick(body)
+    }
+
+    @Operation(
+        summary = "오늘 손님 후원 클릭 수 조회",
+        description = "KST 자정 이후 기록된 손님 후원 버튼 클릭 수. 후원 모달에서 '오늘 N명이 함께했어요' 표시에 사용합니다."
+    )
+    @GetMapping("/donations/customer-clicks/today-count")
+    fun getTodayCustomerDonationClickCount(): CustomerDonationClickCountResponse {
+        return customerDonationFacade.getTodayCount()
+    }
+}

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/dto/common/CustomerDonationClickCountResponse.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/dto/common/CustomerDonationClickCountResponse.kt
@@ -1,0 +1,5 @@
+package com.kioschool.kioschoolapi.domain.donation.dto.common
+
+data class CustomerDonationClickCountResponse(
+    val todayCount: Long,
+)

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/dto/request/RecordCustomerDonationClickRequestBody.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/dto/request/RecordCustomerDonationClickRequestBody.kt
@@ -1,0 +1,7 @@
+package com.kioschool.kioschoolapi.domain.donation.dto.request
+
+data class RecordCustomerDonationClickRequestBody(
+    val workspaceId: Long? = null,
+    val variant: String? = null,
+    val amount: Int? = null,
+)

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/entity/CustomerDonationClick.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/entity/CustomerDonationClick.kt
@@ -1,0 +1,14 @@
+package com.kioschool.kioschoolapi.domain.donation.entity
+
+import com.kioschool.kioschoolapi.global.common.entity.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "customer_donation_click")
+class CustomerDonationClick(
+    // 후속 분석용. 지금은 count(*)만 쓰고 아무 컬럼도 읽지 않는다.
+    var workspaceId: Long? = null,
+    var variant: String? = null,
+    var amount: Int? = null,
+) : BaseEntity()

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/facade/CustomerDonationFacade.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/facade/CustomerDonationFacade.kt
@@ -1,0 +1,23 @@
+package com.kioschool.kioschoolapi.domain.donation.facade
+
+import com.kioschool.kioschoolapi.domain.donation.dto.common.CustomerDonationClickCountResponse
+import com.kioschool.kioschoolapi.domain.donation.dto.request.RecordCustomerDonationClickRequestBody
+import com.kioschool.kioschoolapi.domain.donation.service.CustomerDonationService
+import org.springframework.stereotype.Component
+
+@Component
+class CustomerDonationFacade(
+    private val customerDonationService: CustomerDonationService,
+) {
+    fun recordClick(body: RecordCustomerDonationClickRequestBody): CustomerDonationClickCountResponse {
+        val todayCount = customerDonationService.recordClick(
+            workspaceId = body.workspaceId,
+            variant = body.variant?.trim()?.takeIf { it.isNotEmpty() },
+            amount = body.amount,
+        )
+        return CustomerDonationClickCountResponse(todayCount)
+    }
+
+    fun getTodayCount(): CustomerDonationClickCountResponse =
+        CustomerDonationClickCountResponse(customerDonationService.getTodayCount())
+}

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/repository/CustomerDonationClickRepository.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/repository/CustomerDonationClickRepository.kt
@@ -1,0 +1,11 @@
+package com.kioschool.kioschoolapi.domain.donation.repository
+
+import com.kioschool.kioschoolapi.domain.donation.entity.CustomerDonationClick
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+interface CustomerDonationClickRepository : JpaRepository<CustomerDonationClick, Long> {
+    fun countByCreatedAtGreaterThanEqual(start: LocalDateTime): Long
+}

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/service/CustomerDonationService.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/service/CustomerDonationService.kt
@@ -1,0 +1,27 @@
+package com.kioschool.kioschoolapi.domain.donation.service
+
+import com.kioschool.kioschoolapi.domain.donation.entity.CustomerDonationClick
+import com.kioschool.kioschoolapi.domain.donation.repository.CustomerDonationClickRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class CustomerDonationService(
+    private val customerDonationClickRepository: CustomerDonationClickRepository,
+) {
+    @Transactional(rollbackFor = [Exception::class])
+    fun recordClick(workspaceId: Long?, variant: String?, amount: Int?): Long {
+        customerDonationClickRepository.save(
+            CustomerDonationClick(
+                workspaceId = workspaceId,
+                variant = variant,
+                amount = amount,
+            )
+        )
+        return getTodayCount()
+    }
+
+    fun getTodayCount(): Long =
+        customerDonationClickRepository.countByCreatedAtGreaterThanEqual(LocalDate.now().atStartOfDay())
+}

--- a/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/service/CustomerDonationService.kt
+++ b/src/main/kotlin/com/kioschool/kioschoolapi/domain/donation/service/CustomerDonationService.kt
@@ -4,7 +4,7 @@ import com.kioschool.kioschoolapi.domain.donation.entity.CustomerDonationClick
 import com.kioschool.kioschoolapi.domain.donation.repository.CustomerDonationClickRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Service
 class CustomerDonationService(
@@ -22,6 +22,20 @@ class CustomerDonationService(
         return getTodayCount()
     }
 
+    // "오늘" = 키오스쿨 영업일(09:00 ~ 익일 08:59). DashboardFacade / OrderStatisticsService와 동일 규칙.
     fun getTodayCount(): Long =
-        customerDonationClickRepository.countByCreatedAtGreaterThanEqual(LocalDate.now().atStartOfDay())
+        customerDonationClickRepository.countByCreatedAtGreaterThanEqual(startOfBusinessDay())
+
+    private fun startOfBusinessDay(): LocalDateTime {
+        val now = LocalDateTime.now()
+        return if (now.hour < BUSINESS_DAY_START_HOUR) {
+            now.minusDays(1).withHour(BUSINESS_DAY_START_HOUR).withMinute(0).withSecond(0).withNano(0)
+        } else {
+            now.withHour(BUSINESS_DAY_START_HOUR).withMinute(0).withSecond(0).withNano(0)
+        }
+    }
+
+    companion object {
+        private const val BUSINESS_DAY_START_HOUR = 9
+    }
 }

--- a/src/main/resources/db/changelog/2026/09/07-01-changelog.xml
+++ b/src/main/resources/db/changelog/2026/09/07-01-changelog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+  <changeSet author="ji-inpark" id="customer-donation-click-1">
+    <createTable tableName="customer_donation_click">
+      <column autoIncrement="true" name="id" type="BIGINT">
+        <constraints nullable="false" primaryKey="true"/>
+      </column>
+      <column name="workspace_id" type="BIGINT"/>
+      <column name="variant" type="VARCHAR(50)"/>
+      <column name="amount" type="INT"/>
+      <column name="created_at" type="TIMESTAMP WITHOUT TIME ZONE"/>
+      <column name="updated_at" type="TIMESTAMP WITHOUT TIME ZONE"/>
+    </createTable>
+    <createIndex indexName="idx_customer_donation_click_created_at" tableName="customer_donation_click">
+      <column name="created_at"/>
+    </createIndex>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## 배경

손님 후원 카드 v2([KioSchool#545](https://github.com/KioSchool/KioSchool/pull/545))가 "오늘 몇 명이 함께했어요" 사회적 증거와 감사 화면을 추가하면서, 클릭 수를 서버에 기록·집계할 곳이 필요해졌다. 프론트는 딥링크 방식이라 실제 송금 완료를 알 수 없어, 이 API가 세는 것은 **"후원 버튼 탭 수"**다.

설계 문서: `KioSchool/docs/superpowers/specs/2026-09-07-bm-l3-customer-donation-design.md` 13.6절

## 이 PR이 하는 것

새 도메인 `domain/donation/`. `inquiry` 도메인 레이어링(entity → repository → service → facade → controller + dto)을 그대로 따른다.

**엔드포인트 2개 (게스트, 무인증 — `/donations/**`는 `/admin`·`/super-admin` prefix가 아니라 `SecurityConfiguration`의 `permitAll` 기본값에 걸림, 설정 변경 없음):**

```
POST /donations/customer-clicks
  body: { workspaceId?: Long, variant?: String, amount?: Int }   (모든 필드 optional)
  201 → { todayCount: Long }

GET /donations/customer-clicks/today-count
  200 → { todayCount: Long }
```

**`customer_donation_click` 테이블**: 탭마다 1행 영구 저장. `BaseEntity`(id, created_at, updated_at) + nullable `workspace_id` / `variant` / `amount`(후속 분석용, 지금은 `count(*)`만 사용). `created_at` 인덱스.

**"오늘 카운트"는 리셋되는 카운터가 아니다.** `countByCreatedAtGreaterThanEqual(startOfBusinessDay())` — 영업일 09:00에 0부터 시작하는 건 필터 창 이동이지 데이터 삭제가 아니다. 누적·일자별·워크스페이스별·변형별 집계는 같은 테이블에서 나중에 언제든 가능.

## Liquibase

`src/main/resources/db/changelog/2026/09/07-01-changelog.xml` 추가. `changelog-master.yaml`이 `includeAll: { path: db/changelog/ }`라 경로순으로 자동 포함(2026/08 항목들 다음). **master yaml 수정 없음.** 컬럼 타입 표기는 기존 `2026/08/29-01-changelog.xml`의 `inquiry` 테이블과 일치(`TIMESTAMP WITHOUT TIME ZONE`, 문자열 changeSet id).

## 검증

- `./gradlew build` BUILD SUCCESSFUL, 기존 테스트 전부 통과
- **머지/배포 전 사람이 확인 필요**:
  - 로컬 DB에 마이그레이션 적용 → `customer_donation_click` 테이블 + `idx_customer_donation_click_created_at` 인덱스 생성 확인
  - `curl -s -X POST localhost:8080/donations/customer-clicks -H 'Content-Type: application/json' -d '{"workspaceId":1,"variant":"A","amount":1000}'` → `{"todayCount":1}`
  - `curl -s localhost:8080/donations/customer-clicks/today-count` → `{"todayCount":1}`

## 배포 순서

이 API가 **먼저** dev에 배포돼야(마이그레이션 반영) 프론트 v2가 API를 칠 수 있다.

## 알려진 한계 (의도적)

- 레이트리밋/중복 방지 없음 — 허영 카운터, 저위험. 남용 관측 시 IP 스로틀 추가.
- "오늘"은 키오스쿨 **영업일 09:00 ~ 익일 08:59** 기준(`DashboardFacade`와 동일 규칙). 자정이 아닌 이유: 축제 주점이 자정을 넘겨 운영하면 하룻밤이 두 날로 쪼개짐. TZ는 `KioSchoolApiApplication.kt`가 `TimeZone.setDefault("Asia/Seoul")` 강제라 KST 고정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

